### PR TITLE
TimeUnit.SECONDS.sleep(1) equals Thread.sleep(1000), but the former is more readable.

### DIFF
--- a/src/main/scala/com/boundary/ordasity/Cluster.scala
+++ b/src/main/scala/com/boundary/ordasity/Cluster.scala
@@ -295,7 +295,7 @@ class Cluster(val name: String, val listener: Listener, config: ClusterConfig)
       } else {
         log.warn("Unable to register with Zookeeper on launch. " +
           "Is %s already running on this host? Retrying in 1 second...", name)
-        Thread.sleep(1000)
+	TimeUnit.SECONDS.sleep(1)       
       }
     }
   }

--- a/src/main/scala/com/boundary/ordasity/Cluster.scala
+++ b/src/main/scala/com/boundary/ordasity/Cluster.scala
@@ -295,7 +295,7 @@ class Cluster(val name: String, val listener: Listener, config: ClusterConfig)
       } else {
         log.warn("Unable to register with Zookeeper on launch. " +
           "Is %s already running on this host? Retrying in 1 second...", name)
-	   TimeUnit.SECONDS.sleep(1)
+            TimeUnit.SECONDS.sleep(1)
       }
     }
   }

--- a/src/main/scala/com/boundary/ordasity/Cluster.scala
+++ b/src/main/scala/com/boundary/ordasity/Cluster.scala
@@ -295,7 +295,7 @@ class Cluster(val name: String, val listener: Listener, config: ClusterConfig)
       } else {
         log.warn("Unable to register with Zookeeper on launch. " +
           "Is %s already running on this host? Retrying in 1 second...", name)
-	TimeUnit.SECONDS.sleep(1)       
+	   TimeUnit.SECONDS.sleep(1)
       }
     }
   }


### PR DESCRIPTION
And TimeUnit.{HOURS, MINUTES, SECONDS}.sleep(x) is 1.6+ ;-)

But, please, feel free to reject this Pull Request if you think it's utterly irrelevant. 

PS: Excuse me, I've messed up indentation in the process (tried to repair, but may require further commits). 
