### PR TITLE
Fix: Don't assume the zk client hasn't yet connected

### DIFF
--- a/src/main/scala/com/boundary/ordasity/Cluster.scala
+++ b/src/main/scala/com/boundary/ordasity/Cluster.scala
@@ -178,11 +178,16 @@ class Cluster(val name: String, val listener: Listener, config: ClusterConfig)
           log.info("Using my own ZooKeeper (hosts: %s)", hosts)
           new ZooKeeperClient(Amount.of(config.zkTimeout, Time.MILLISECONDS), hosts)
       }
+
+      log.info("Ensuring ZooKeeper connection is live")
+      zk.get()
+      log.info("Simulating newly established session to kickoff cluster startup")
+      connectionWatcher.process(new WatchedEvent(null, KeeperState.SyncConnected, null))
       log.info("Registering connection watcher.")
       zk.register(connectionWatcher)
     }
 
-    log.info("Ensuring ZooKeeper connection is live")
+    log.info("Ensuring ZooKeeper connection is live (still)")
     zk.get()
   }
 

--- a/src/main/scala/com/boundary/ordasity/Cluster.scala
+++ b/src/main/scala/com/boundary/ordasity/Cluster.scala
@@ -167,17 +167,16 @@ class Cluster(val name: String, val listener: Listener, config: ClusterConfig)
    */
   def connect(injectedClient: Option[ZooKeeperClient] = None) {
     if (!initialized.get) {
-      val hosts = config.hosts.split(",").map { server =>
-        val host = server.split(":")(0)
-        val port = Integer.parseInt(server.split(":")(1))
-        new InetSocketAddress(host, port)
-      }.toList
-
       zk = injectedClient match {
         case Some(zk) =>
           log.info("Using user-supplied ZooKeeper")
           zk
         case None =>
+          val hosts = config.hosts.split(",").map { server =>
+            val host = server.split(":")(0)
+            val port = Integer.parseInt(server.split(":")(1))
+            new InetSocketAddress(host, port)
+          }.toList
           log.info("Using my own ZooKeeper (hosts: %s)", hosts)
           new ZooKeeperClient(Amount.of(config.zkTimeout, Time.MILLISECONDS), hosts)
       }

--- a/src/main/scala/com/boundary/ordasity/Cluster.scala
+++ b/src/main/scala/com/boundary/ordasity/Cluster.scala
@@ -112,33 +112,36 @@ class Cluster(val name: String, val listener: Listener, config: ClusterConfig)
 
   val connectionWatcher = new Watcher {
     def process(event: WatchedEvent) {
-      event.getState match {
-        case KeeperState.SyncConnected => {
-          log.info("ZooKeeper session established.")
-          connected.set(true)
-          try {
-            if (state.get() != NodeState.Shutdown)
-              onConnect()
-            else
-              log.info("This node is shut down. ZK connection re-established, but not relaunching.")
-          } catch {
-            case e:Exception =>
-              log.error(e, "Exception during zookeeper connection established callback")
+      // Synchronize since we are triggered by both the zk event thread and the user thread
+      synchronized {
+        event.getState match {
+          case KeeperState.SyncConnected => {
+            log.info("ZooKeeper session established.")
+            connected.set(true)
+            try {
+              if (state.get() != NodeState.Shutdown)
+                onConnect()
+              else
+                log.info("This node is shut down. ZK connection re-established, but not relaunching.")
+            } catch {
+              case e:Exception =>
+                log.error(e, "Exception during zookeeper connection established callback")
+            }
           }
+          case KeeperState.Expired =>
+            log.info("ZooKeeper session expired.")
+            connected.set(false)
+            forceShutdown()
+            awaitReconnect()
+          case KeeperState.Disconnected =>
+            log.info("ZooKeeper session disconnected. Awaiting reconnect...")
+            connected.set(false)
+            awaitReconnect()
+          case x: Any =>
+            log.info("ZooKeeper session interrupted. Shutting down due to %s", x)
+            connected.set(false)
+            awaitReconnect()
         }
-        case KeeperState.Expired =>
-          log.info("ZooKeeper session expired.")
-          connected.set(false)
-          forceShutdown()
-          awaitReconnect()
-        case KeeperState.Disconnected =>
-          log.info("ZooKeeper session disconnected. Awaiting reconnect...")
-          connected.set(false)
-          awaitReconnect()
-        case x: Any =>
-          log.info("ZooKeeper session interrupted. Shutting down due to %s", x)
-          connected.set(false)
-          awaitReconnect()
       }
     }
 

--- a/src/main/scala/com/boundary/ordasity/Cluster.scala
+++ b/src/main/scala/com/boundary/ordasity/Cluster.scala
@@ -172,12 +172,12 @@ class Cluster(val name: String, val listener: Listener, config: ClusterConfig)
           log.info("Using user-supplied ZooKeeper")
           zk
         case None =>
+          log.info("Using my own ZooKeeper (hosts: %s)", config.hosts)
           val hosts = config.hosts.split(",").map { server =>
             val host = server.split(":")(0)
             val port = Integer.parseInt(server.split(":")(1))
             new InetSocketAddress(host, port)
           }.toList
-          log.info("Using my own ZooKeeper (hosts: %s)", hosts)
           new ZooKeeperClient(Amount.of(config.zkTimeout, Time.MILLISECONDS), hosts)
       }
 

--- a/src/test/scala/com/boundary/ordasity/ClusterSpec.scala
+++ b/src/test/scala/com/boundary/ordasity/ClusterSpec.scala
@@ -448,7 +448,7 @@ class ClusterSpec extends Spec with Logging {
       val policy = mock[BalancingPolicy]
       cluster.balancingPolicy = policy
 
-     // Pretend that the paths exist for the ZooKeeperMaps we're creating
+      // Pretend that the paths exist for the ZooKeeperMaps we're creating
       mockZK.exists(any[String], any[Watcher]).returns(mock[Stat])
 
       cluster.setState(NodeState.Shutdown)

--- a/src/test/scala/com/boundary/ordasity/ClusterSpec.scala
+++ b/src/test/scala/com/boundary/ordasity/ClusterSpec.scala
@@ -391,7 +391,6 @@ class ClusterSpec extends Spec with Logging {
       verify.one(mockClusterListener).onJoin(any)
       verify.one(policy).onConnect()
       cluster.state.get().must(be(NodeState.Started))
-      cluster.watchesRegistered.set(true)
     }
 
     @Test def `connect` {
@@ -413,7 +412,6 @@ class ClusterSpec extends Spec with Logging {
       verify.one(mockClusterListener).onJoin(any)
       verify.one(policy).onConnect()
       cluster.state.get().must(be(NodeState.Started))
-      cluster.watchesRegistered.set(true)
     }
 
     @Test def `join when draining` {
@@ -459,7 +457,6 @@ class ClusterSpec extends Spec with Logging {
       verify.one(mockClusterListener).onJoin(any)
       verify.one(policy).onConnect()
       cluster.state.get().must(be(NodeState.Started))
-      cluster.watchesRegistered.set(true)
     }
 
     @Test def `join after shutdown` {
@@ -479,7 +476,6 @@ class ClusterSpec extends Spec with Logging {
       verify.one(mockClusterListener).onJoin(any)
       verify.one(policy).onConnect()
       cluster.state.get().must(be(NodeState.Started))
-      cluster.watchesRegistered.set(true)
     }
 
 

--- a/src/test/scala/com/boundary/ordasity/ClusterSpec.scala
+++ b/src/test/scala/com/boundary/ordasity/ClusterSpec.scala
@@ -272,13 +272,13 @@ class ClusterSpec extends Spec with Logging {
 
       cluster.registerWatchers()
 
-      cluster.nodes.isInstanceOf[ZooKeeperMap[String]].must(be(true))
-      cluster.allWorkUnits.isInstanceOf[ZooKeeperMap[String]].must(be(true))
-      cluster.workUnitMap.isInstanceOf[ZooKeeperMap[String]].must(be(true))
+      cluster.nodes.isInstanceOf[ZooKeeperMap[_]].must(be(true))
+      cluster.allWorkUnits.isInstanceOf[ZooKeeperMap[_]].must(be(true))
+      cluster.workUnitMap.isInstanceOf[ZooKeeperMap[_]].must(be(true))
 
       // Not using soft handoff (TODO: assert ZKMap w/soft handoff on)
-      cluster.handoffRequests.isInstanceOf[HashMap[String, String]].must(be(true))
-      cluster.handoffResults.isInstanceOf[HashMap[String, String]].must(be(true))
+      cluster.handoffRequests.isInstanceOf[HashMap[_, _]].must(be(true))
+      cluster.handoffResults.isInstanceOf[HashMap[_, _]].must(be(true))
 
       // TODO: Test loadMap isinstanceof zkmap with smart balancing on.
     }


### PR DESCRIPTION
If the user supplies their own zk client to cluster.join (or cluster.connect), and their zk client has already established a session, then the cluster will register a watch for a SyncConnected event but never receive one, since it has already fired long ago, before the cluster started listening.

This bug was introduced in my earlier #13, which was a simple change that quietly violated the assumption that the cluster's zk client would trigger a SyncConnected after cluster.join.

This fix depends on (and includes) #14.
