### PR TITLE
Set a watch for immediate handoff of work.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,13 @@
           <version>1.8.5</version>
           <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.6.4</version>
+            <scope>test</scope>
+        </dependency>
       
     </dependencies>
 

--- a/src/main/scala/com/boundary/ordasity/ZKUtils.scala
+++ b/src/main/scala/com/boundary/ordasity/ZKUtils.scala
@@ -23,6 +23,7 @@ import org.apache.zookeeper.ZooDefs.Ids
 import org.apache.zookeeper.KeeperException.{NoNodeException, NodeExistsException}
 import org.apache.zookeeper.{WatchedEvent, Watcher, KeeperException, CreateMode}
 import org.apache.zookeeper.Watcher.Event.EventType
+import org.apache.zookeeper.data.Stat
 
 object ZKUtils extends Logging {
 
@@ -96,6 +97,18 @@ object ZKUtils extends Logging {
       case e: Exception =>
         log.error(e, "Error getting data for ZNode at path %s", path)
         null
+    }
+  }
+
+  def exists(zk: ZooKeeperClient, path: String, watcher: Watcher = null) : Option[Stat] = {
+    try {
+      Option(zk.get().exists(path, watcher))
+    } catch {
+      case e: InterruptedException =>
+        throw e
+      case e: Exception =>
+        log.error(e, "Failed to get stat for ZNode at path %s", path)
+        None
     }
   }
 

--- a/src/main/scala/com/boundary/ordasity/listeners/HandoffResultsListener.scala
+++ b/src/main/scala/com/boundary/ordasity/listeners/HandoffResultsListener.scala
@@ -106,14 +106,14 @@ class HandoffResultsListener(cluster: Cluster, config: ClusterConfig)
       }
     }
 
-    val stat = cluster.zk.get().exists(path, new Watcher {
+    val stat = ZKUtils.exists(cluster.zk, path, new Watcher {
       def process(event: WatchedEvent) {
         // Don't really care about the type of event here - call unconditionally to clean up state
         completeHandoff()
       }
     })
     // Unlikely that peer will have already deleted znode, but handle it regardless
-    if (stat == null) {
+    if (stat.isEmpty) {
       log.warn("Peer already deleted znode of %s", workUnit)
       completeHandoff()
     }

--- a/src/main/scala/com/boundary/ordasity/listeners/HandoffResultsListener.scala
+++ b/src/main/scala/com/boundary/ordasity/listeners/HandoffResultsListener.scala
@@ -1,5 +1,5 @@
 //
-// Copyright 2011-2012, Boundary
+// Copyright 2011-2013, Boundary
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ class HandoffResultsListener(cluster: Cluster, config: ClusterConfig)
    * Attempts to establish a final claim to the node handed off to me in ZooKeeper, and
    * repeats execution of the task every two seconds until it is complete.
    */
-  def finishHandoff(workUnit: String, retryTime: Int = 2000) {
+  def finishHandoff(workUnit: String) {
     log.info("Handoff of %s to me acknowledged. Deleting claim ZNode for %s and waiting for %s to " +
       "shutdown work.", workUnit, workUnit, cluster.getOrElse(cluster.workUnitMap, workUnit, "(None)"))
 


### PR DESCRIPTION
Currently, ordasity will schedule both the node handing off the work
unit and the new node accepting the work unit with a delay, after which
the new node will attempt to claim the work unit by creating an
ephemeral node in ZK. There is a slight race condition here, so often
times the handoff is delayed by a fixed delay time (of 2s) before the
node can be claimed.

This behavior has been modified to use a ZK watch on the ephemeral node
owned by the node handing off the work unit. When the watch fires, the
new node will more reliably be able to claim the work unit without
triggering the delay.
