### PR TITLE
wrapper class for ClusterConfig

### DIFF
--- a/src/main/scala/com/boundary/ordasity/ClusterConfigBuilder.scala
+++ b/src/main/scala/com/boundary/ordasity/ClusterConfigBuilder.scala
@@ -1,0 +1,38 @@
+package com.boundary.ordasity
+
+import scala.reflect.BeanProperty
+import java.net.InetAddress
+
+class ClusterConfigBuilder {
+
+  // Defaults
+  @BeanProperty var hosts = ""
+  @BeanProperty var enableAutoRebalance = true
+  @BeanProperty var autoRebalanceInterval = 60
+  @BeanProperty var drainTime = 60
+  @BeanProperty var useSmartBalancing = false
+  @BeanProperty var zkTimeout = 3000
+  @BeanProperty var workUnitName = "work-units"
+  @BeanProperty var workUnitShortName = "work"
+  @BeanProperty var nodeId = InetAddress.getLocalHost.getHostName
+  @BeanProperty var useSoftHandoff = false
+  @BeanProperty var handoffShutdownDelay = 10
+  
+
+  def build() : ClusterConfig = {
+    val config = new ClusterConfig()
+    config.setHosts(hosts)
+    config.setAutoRebalance(enableAutoRebalance)
+    config.setRebalanceInterval(autoRebalanceInterval)
+    config.setDrainTime(drainTime)
+    config.useSmartBalancing(useSmartBalancing)
+    config.setZKTimeout(zkTimeout)
+    config.setWorkUnitName(workUnitName)
+    config.setWorkUnitShortName(workUnitShortName)
+    config.setNodeId(nodeId)
+    config.setUseSoftHandoff(useSoftHandoff)
+    config.setHandoffShutdownDelay(handoffShutdownDelay)
+    config
+  }
+  
+}


### PR DESCRIPTION
I am working on a project that uses Dropwizard v.0.6.2, so all included config files must use @scala.reflect.BeanProperty. To avoid changing the ordasity interface, I created a wrapper class for ClusterConfig.scala.
