### PR TITLE
Remove race condition on shutdown.

### DIFF
--- a/src/main/scala/com/boundary/ordasity/Cluster.scala
+++ b/src/main/scala/com/boundary/ordasity/Cluster.scala
@@ -472,10 +472,13 @@ class Cluster(val name: String, val listener: Listener, config: ClusterConfig)
     if (doLog) log.info("Shutting down %s: %s...", config.workUnitName, workUnit)
     myWorkUnits.remove(workUnit)
     claimedForHandoff.remove(workUnit)
-    val path = "/%s/claimed-%s/%s".format(name, config.workUnitShortName, workUnit)
-    if (deleteZNode) ZKUtils.delete(zk, path)
     balancingPolicy.onShutdownWork(workUnit)
-    listener.shutdownWork(workUnit)
+    try {
+      listener.shutdownWork(workUnit)
+    } finally {
+      val path = "/%s/claimed-%s/%s".format(name, config.workUnitShortName, workUnit)
+      if (deleteZNode) ZKUtils.delete(zk, path)
+    }
   }
 
 


### PR DESCRIPTION
The order of operations when shutting down a work unit is wrong (it
removes the ZNode before it allows the listener to shut down work). This
just swaps the order so that another node in the cluster won't attempt
to claim the work until it has been shut down.
