### PR TITLE
Atomically delete claim for a work unit.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,10 @@
             <version>0.0.46</version>
             <exclusions>
                 <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>jline</groupId>
                     <artifactId>jline</artifactId>
                 </exclusion>
@@ -67,7 +71,7 @@
         <dependency>
           <groupId>org.mockito</groupId>
           <artifactId>mockito-all</artifactId>
-          <version>1.8.5</version>
+          <version>1.9.5</version>
           <scope>test</scope>
         </dependency>
 
@@ -82,7 +86,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
             <version>1.7.6</version>
-            <scope>test</scope>
         </dependency>
       
     </dependencies>

--- a/src/main/scala/com/boundary/ordasity/ZKUtils.scala
+++ b/src/main/scala/com/boundary/ordasity/ZKUtils.scala
@@ -20,8 +20,7 @@ import com.twitter.common.zookeeper.{ZooKeeperUtils, ZooKeeperClient}
 
 import org.apache.zookeeper.ZooDefs.Ids
 import org.apache.zookeeper.KeeperException.{NoNodeException, NodeExistsException}
-import org.apache.zookeeper.{WatchedEvent, Watcher, KeeperException, CreateMode}
-import org.apache.zookeeper.Watcher.Event.EventType
+import org.apache.zookeeper.{Watcher, CreateMode}
 import org.apache.zookeeper.data.Stat
 import com.boundary.logula.Logging
 
@@ -65,6 +64,31 @@ object ZKUtils extends Logging {
     }
   }
 
+  /**
+   * Attempts to atomically delete the ZNode with the specified path and value. Should be preferred over calling
+   * delete() if the value is known.
+   *
+   * @param zk ZooKeeper client.
+   * @param path Path to be deleted.
+   * @param expectedValue The expected value of the ZNode at the specified path.
+   * @return True if the path was deleted, false otherwise.
+   */
+  def deleteAtomic(zk: ZooKeeperClient, path: String, expectedValue: String) : Boolean = {
+    val stat = new Stat()
+    val value = getWithStat(zk, path, Some(stat))
+    if (!expectedValue.equals(value)) {
+      return false
+    }
+    try {
+      zk.get().delete(path, stat.getVersion)
+      true
+    } catch {
+      case e: Exception =>
+        log.error(e, "Failed to delete path %s with expected value %s", path, expectedValue)
+        false
+    }
+  }
+
   def set(zk: ZooKeeperClient, path: String, data: String) : Boolean = {
     try {
       zk.get().setData(path, data.getBytes, -1)
@@ -88,8 +112,12 @@ object ZKUtils extends Logging {
   }
 
   def get(zk: ZooKeeperClient, path: String) : String = {
+    getWithStat(zk, path, None)
+  }
+
+  def getWithStat(zk: ZooKeeperClient, path: String, stat: Option[Stat]) : String = {
     try {
-      val value = zk.get.getData(path, false, null)
+      val value = zk.get.getData(path, false, stat.orNull)
       new String(value)
     } catch {
       case e: NoNodeException =>
@@ -110,45 +138,6 @@ object ZKUtils extends Logging {
         log.error(e, "Failed to get stat for ZNode at path %s", path)
         None
     }
-  }
-
-  /**
-   * Watches a node. When the node's data is changed, onDataChanged will be called with the
-   * new data value as a byte array. If the node is deleted, onDataChanged will be called with
-   * None and will track the node's re-creation with an existence watch. Borrowed from the Twitter
-   * scala-zookeeper-client by Alex Payne, released under Apache 2.0. THANKS AL3X!
-   */
-  def watchNode(zk: ZooKeeperClient, node : String, onDataChanged : Option[Array[Byte]] => Unit) {
-    log.debug("Watching node %s", node)
-    def updateData {
-      try {
-        onDataChanged(Some(zk.get.getData(node, dataGetter, null)))
-      } catch {
-        case e:KeeperException => {
-          log.warn("Failed to read node %s: %s", node, e)
-          deletedData
-        }
-      }
-    }
-
-    def deletedData {
-      onDataChanged(None)
-      if (zk.get.exists(node, dataGetter) != null) {
-        // Node was re-created by the time we called zk.exist
-        updateData
-      }
-    }
-
-    def dataGetter = new Watcher {
-      def process(event : WatchedEvent) {
-        if (event.getType == EventType.NodeDataChanged || event.getType == EventType.NodeCreated) {
-          updateData
-        } else if (event.getType == EventType.NodeDeleted) {
-          deletedData
-        }
-      }
-    }
-    updateData
   }
 
 }

--- a/src/main/scala/com/boundary/ordasity/balancing/BalancingPolicy.scala
+++ b/src/main/scala/com/boundary/ordasity/balancing/BalancingPolicy.scala
@@ -118,7 +118,7 @@ abstract class BalancingPolicy(cluster: Cluster, config: ClusterConfig)
 
     val path = {
       if (claimForHandoff) "/%s/handoff-result/%s".format(cluster.name, workUnit)
-      else "/%s/claimed-%s/%s".format(cluster.name, config.workUnitShortName, workUnit)
+      else cluster.workUnitClaimPath(workUnit)
     }
 
     val created = ZKUtils.createEphemeral(cluster.zk, path, cluster.myNodeID)
@@ -140,7 +140,7 @@ abstract class BalancingPolicy(cluster: Cluster, config: ClusterConfig)
    * (i.e., deleted by the node which previously owned it).
    */
   protected def claimWorkPeggedToMe(workUnit: String) {
-    val path = "/%s/claimed-%s/%s".format(cluster.name, config.workUnitShortName, workUnit)
+    val path = cluster.workUnitClaimPath(workUnit)
 
     while (true) {
       if (ZKUtils.createEphemeral(cluster.zk, path, cluster.myNodeID) || cluster.znodeIsMe(path)) {

--- a/src/main/scala/com/boundary/ordasity/listeners/HandoffResultsListener.scala
+++ b/src/main/scala/com/boundary/ordasity/listeners/HandoffResultsListener.scala
@@ -70,7 +70,7 @@ class HandoffResultsListener(cluster: Cluster, config: ClusterConfig)
       def run() {
         log.info("Shutting down %s following handoff to %s.",
           workUnit, cluster.getOrElse(cluster.handoffResults, workUnit, "(None)"))
-        cluster.shutdownWork(workUnit, doLog = false, deleteZNode = true)
+        cluster.shutdownWork(workUnit, doLog = false)
 
         if (cluster.myWorkUnits.size() == 0 && cluster.state.get() == NodeState.Draining)
           cluster.shutdown()
@@ -87,7 +87,7 @@ class HandoffResultsListener(cluster: Cluster, config: ClusterConfig)
     log.info("Handoff of %s to me acknowledged. Deleting claim ZNode for %s and waiting for %s to " +
       "shutdown work.", workUnit, workUnit, cluster.getOrElse(cluster.workUnitMap, workUnit, "(None)"))
 
-    val path = "/%s/claimed-%s/%s".format(cluster.name, config.workUnitShortName, workUnit)
+    val path = cluster.workUnitClaimPath(workUnit)
     val completeHandoff = () => {
       try {
         log.info("Completing handoff of %s", workUnit)

--- a/src/test/scala/com/boundary/ordasity/ZKUtilsSpec.scala
+++ b/src/test/scala/com/boundary/ordasity/ZKUtilsSpec.scala
@@ -23,6 +23,7 @@ import org.apache.zookeeper.{CreateMode, ZooKeeper}
 import org.apache.zookeeper.KeeperException.NoNodeException
 import com.simple.simplespec.Spec
 import com.boundary.logula.Logging
+import org.apache.zookeeper.data.Stat
 
 class ZKUtilsSpec extends Spec with Logging {
 
@@ -101,7 +102,7 @@ class ZKUtilsSpec extends Spec with Logging {
       val (mockZK, mockZKClient) = getMockZK()
       val path = "/foo"
       val data = "ohai"
-      mockZK.getData(path, false, null).returns(data.getBytes)
+      mockZK.getData(equalTo(path), any[Boolean], any[Stat]).returns(data.getBytes)
 
       ZKUtils.get(mockZKClient, path).must(be(data))
     }

--- a/src/test/scala/com/boundary/ordasity/balancing/BalancingPolicySpec.scala
+++ b/src/test/scala/com/boundary/ordasity/balancing/BalancingPolicySpec.scala
@@ -25,6 +25,8 @@ import com.twitter.common.zookeeper.ZooKeeperClient
 import org.mockito.Mockito
 import org.apache.zookeeper.KeeperException.NodeExistsException
 import com.simple.simplespec.Spec
+import org.apache.zookeeper.data.Stat
+import com.google.common.base.Charsets
 
 
 class DummyBalancingPolicy(cluster: Cluster, config: ClusterConfig)
@@ -123,6 +125,10 @@ class BalancingPolicySpec extends Spec {
       cluster.myWorkUnits.addAll(workUnits)
       workUnits.foreach(el => cluster.allWorkUnits.put(el, ""))
       workUnits.foreach(el => cluster.workUnitMap.put(el, "testNode"))
+      workUnits.foreach(el =>
+        cluster.zk.get().getData(equalTo(cluster.workUnitClaimPath(el)), any[Boolean], any[Stat])
+          .returns(cluster.myNodeID.getBytes(Charsets.UTF_8))
+      )
 
       balancer.drainToCount(0)
 
@@ -140,6 +146,10 @@ class BalancingPolicySpec extends Spec {
       cluster.workUnitsPeggedToMe.add("two")
       workUnits.foreach(el => cluster.allWorkUnits.put(el, ""))
       workUnits.foreach(el => cluster.workUnitMap.put(el, "testNode"))
+      workUnits.foreach(el =>
+        cluster.zk.get().getData(equalTo(cluster.workUnitClaimPath(el)), any[Boolean], any[Stat])
+          .returns(cluster.myNodeID.getBytes(Charsets.UTF_8))
+      )
 
       balancer.drainToCount(0)
 
@@ -157,6 +167,10 @@ class BalancingPolicySpec extends Spec {
       cluster.workUnitsPeggedToMe.add("two")
       workUnits.foreach(el => cluster.allWorkUnits.put(el, ""))
       workUnits.foreach(el => cluster.workUnitMap.put(el, "testNode"))
+      workUnits.foreach(el =>
+        cluster.zk.get().getData(equalTo(cluster.workUnitClaimPath(el)), any[Boolean], any[Stat])
+          .returns(cluster.myNodeID.getBytes(Charsets.UTF_8))
+      )
 
       balancer.drainToCount(0, doShutdown = true)
 
@@ -174,6 +188,10 @@ class BalancingPolicySpec extends Spec {
       cluster.myWorkUnits.addAll(workUnits)
       workUnits.foreach(el => cluster.allWorkUnits.put(el, ""))
       workUnits.foreach(el => cluster.workUnitMap.put(el, "testNode"))
+      workUnits.foreach(el =>
+        cluster.zk.get().getData(equalTo(cluster.workUnitClaimPath(el)), any[Boolean], any[Stat])
+          .returns(cluster.myNodeID.getBytes(Charsets.UTF_8))
+      )
 
       balancer.drainToCount(0, doShutdown = true)
 
@@ -190,6 +208,10 @@ class BalancingPolicySpec extends Spec {
       cluster.myWorkUnits.addAll(workUnits)
       workUnits.foreach(el => cluster.allWorkUnits.put(el, ""))
       workUnits.foreach(el => cluster.workUnitMap.put(el, "testNode"))
+      workUnits.foreach(el =>
+        cluster.zk.get().getData(equalTo(cluster.workUnitClaimPath(el)), any[Boolean], any[Stat])
+          .returns(cluster.myNodeID.getBytes(Charsets.UTF_8))
+      )
 
       cluster.zk.get().create(any, any, any, any).returns("")
       balancer.drainToCount(3, useHandoff = true)

--- a/src/test/scala/com/boundary/ordasity/balancing/CountBalancingPolicySpec.scala
+++ b/src/test/scala/com/boundary/ordasity/balancing/CountBalancingPolicySpec.scala
@@ -23,6 +23,8 @@ import collection.JavaConversions._
 import org.apache.zookeeper.ZooKeeper
 import com.twitter.common.zookeeper.ZooKeeperClient
 import com.simple.simplespec.Spec
+import org.apache.zookeeper.data.Stat
+import com.google.common.base.Charsets
 
 class CountBalancingPolicySpec extends Spec {
 
@@ -43,7 +45,7 @@ class CountBalancingPolicySpec extends Spec {
         cluster.allWorkUnits.put(el, el))
 
       balancer.activeNodeSize().must(be(2))
-      balancer.fairShare.must(be(4))
+      balancer.fairShare().must(be(4))
     }
 
 
@@ -55,6 +57,10 @@ class CountBalancingPolicySpec extends Spec {
       cluster.myWorkUnits.addAll(workUnits)
       workUnits.foreach(el => cluster.allWorkUnits.put(el, ""))
       workUnits.foreach(el => cluster.workUnitMap.put(el, "testNode"))
+      workUnits.foreach(el =>
+        cluster.zk.get().getData(equalTo(cluster.workUnitClaimPath(el)), any[Boolean], any[Stat])
+          .returns(cluster.myNodeID.getBytes(Charsets.UTF_8))
+      )
 
       balancer.rebalance()
 

--- a/src/test/scala/com/boundary/ordasity/balancing/MeteredBalancingPolicySpec.scala
+++ b/src/test/scala/com/boundary/ordasity/balancing/MeteredBalancingPolicySpec.scala
@@ -25,6 +25,8 @@ import java.util.concurrent.ScheduledFuture
 import com.yammer.metrics.scala.Meter
 import java.util.{LinkedList, HashMap, UUID}
 import com.simple.simplespec.Spec
+import org.apache.zookeeper.data.Stat
+import com.google.common.base.Charsets
 
 class MeteredBalancingPolicySpec extends Spec {
 
@@ -140,6 +142,10 @@ class MeteredBalancingPolicySpec extends Spec {
       map.foreach(el =>
         cluster.allWorkUnits.put(el._1, ""))
       cluster.myWorkUnits.addAll(map.keySet)
+      map.keys.foreach(el =>
+        cluster.zk.get().getData(equalTo(cluster.workUnitClaimPath(el)), any[Boolean], any[Stat])
+          .returns(cluster.myNodeID.getBytes(Charsets.UTF_8))
+      )
       cluster.loadMap = new HashMap[String, Double]
       cluster.loadMap.putAll(map)
 
@@ -161,6 +167,10 @@ class MeteredBalancingPolicySpec extends Spec {
       map.foreach(el =>
         cluster.allWorkUnits.put(el._1, ""))
       cluster.myWorkUnits.addAll(map.keySet)
+      map.keys.foreach(el =>
+        cluster.zk.get().getData(equalTo(cluster.workUnitClaimPath(el)), any[Boolean], any[Stat])
+          .returns(cluster.myNodeID.getBytes(Charsets.UTF_8))
+      )
       cluster.loadMap = new HashMap[String, Double]
       cluster.loadMap.putAll(map)
       balancer.myLoad().must(be(600.0))
@@ -182,6 +192,10 @@ class MeteredBalancingPolicySpec extends Spec {
 
       map.foreach(el =>
         cluster.allWorkUnits.put(el._1, ""))
+      map.keys.foreach(el =>
+        cluster.zk.get().getData(equalTo(cluster.workUnitClaimPath(el)), any[Boolean], any[Stat])
+          .returns(cluster.myNodeID.getBytes(Charsets.UTF_8))
+      )
       cluster.myWorkUnits.addAll(map.keySet)
       cluster.loadMap = new HashMap[String, Double]
       cluster.loadMap.putAll(map)

--- a/src/test/scala/com/boundary/ordasity/listeners/ClusterNodesChangedListenerSpec.scala
+++ b/src/test/scala/com/boundary/ordasity/listeners/ClusterNodesChangedListenerSpec.scala
@@ -36,9 +36,13 @@ class ClusterNodesChangedListenerSpec extends Spec {
       cluster.watchesRegistered.returns(new AtomicBoolean(true))
       cluster.initialized.returns(new AtomicBoolean(true))
 
-      val claimer = new Claimer(cluster)
-      claimer.start
+      val claimer = mock[Claimer]
+      claimer.start()
       cluster.claimer.returns(claimer)
+      claimer.requestClaim().answersWith(invocation => {
+        cluster.claimWork()
+        true
+      })
 
       val listener = new ClusterNodesChangedListener(cluster)
       listener.nodeChanged("foo", NodeInfo(NodeState.Started.toString, 0L))
@@ -52,9 +56,12 @@ class ClusterNodesChangedListenerSpec extends Spec {
       cluster.watchesRegistered.returns(new AtomicBoolean(true))
       cluster.initialized.returns(new AtomicBoolean(true))
 
-      val claimer = new Claimer(cluster)
-      claimer.start
+      val claimer = mock[Claimer]
       cluster.claimer.returns(claimer)
+      claimer.requestClaim().answersWith(invocation => {
+        cluster.claimWork()
+        true
+      })
 
       val listener = new ClusterNodesChangedListener(cluster)
       listener.nodeRemoved("foo")

--- a/src/test/scala/com/boundary/ordasity/listeners/HandoffResultsListenerSpec.scala
+++ b/src/test/scala/com/boundary/ordasity/listeners/HandoffResultsListenerSpec.scala
@@ -77,7 +77,7 @@ class HandoffResultsListenerSpec extends Spec {
       val listener = new HandoffResultsListener(cluster, config)
       listener.shutdownAfterHandoff(workUnit).run()
 
-      verify.one(cluster).shutdownWork(workUnit, false, true)
+      verify.one(cluster).shutdownWork(workUnit, doLog = false)
       verify.no(cluster).shutdown()
     }
 
@@ -100,14 +100,14 @@ class HandoffResultsListenerSpec extends Spec {
       listener.shutdownAfterHandoff(workUnit).run()
 
       // First, verify that we don't trigger full shutdown with a work unit remaining.
-      verify.one(cluster).shutdownWork(workUnit, false, true)
+      verify.one(cluster).shutdownWork(workUnit, doLog = false)
       verify.no(cluster).shutdown()
 
       myWorkUnits.clear()
 
       // Then, verify that we do trigger shutdown once the work unit set is empty.
       listener.shutdownAfterHandoff(workUnit).run()
-      verify.exactly(2)(cluster).shutdownWork(workUnit, false, true)
+      verify.exactly(2)(cluster).shutdownWork(workUnit, doLog = false)
       verify.one(cluster).shutdown()
     }
 
@@ -127,7 +127,7 @@ class HandoffResultsListenerSpec extends Spec {
 
       val path = "/%s/claimed-%s/%s".format(cluster.name, config.workUnitShortName, workUnit)
       mockZK.create(path, cluster.myNodeID.getBytes, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL).returns("")
-      mockZK.getData(path, false, null).returns("otherNode".getBytes)
+      mockZK.getData(equalTo(path), any[Boolean], any[Stat]).returns("otherNode".getBytes)
 
       val captureWatchter = ArgumentCaptor.forClass(classOf[Watcher])
       Mockito.when(mockZK.exists(equalTo(path), captureWatchter.capture())).thenReturn(new Stat())
@@ -174,7 +174,7 @@ class HandoffResultsListenerSpec extends Spec {
       cluster.zk = mockZKClient
 
       val path = "/%s/claimed-%s/%s".format(cluster.name, config.workUnitShortName, workUnit)
-      mockZK.getData(path, false, null).returns("otherNode".getBytes)
+      mockZK.getData(equalTo(path), any[Boolean], any[Stat]).returns("otherNode".getBytes)
 
       Mockito.when(mockZK.create(path, cluster.myNodeID.getBytes, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL)).
         thenReturn("")
@@ -244,39 +244,9 @@ class HandoffResultsListenerSpec extends Spec {
 
       Thread.sleep((config.handoffShutdownDelay * 1000) + 100)
 
-      verify.one(cluster).shutdownWork(workUnit, false, true)
+      verify.one(cluster).shutdownWork(workUnit, doLog = false)
       verify.no(cluster).shutdown()
     }
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/src/test/scala/com/boundary/ordasity/listeners/VerifyIntegrityListenerSpec.scala
+++ b/src/test/scala/com/boundary/ordasity/listeners/VerifyIntegrityListenerSpec.scala
@@ -42,9 +42,13 @@ class VerifyIntegrityListenerSpec extends Spec {
       cluster.workUnitsPeggedToMe.returns(new NonBlockingHashSet[String])
       cluster.balancingPolicy.returns(new MeteredBalancingPolicy(cluster, config))
       cluster.myNodeID.returns("testNode")
-      val claimer = new Claimer(cluster)
-      claimer.start
+      val claimer = mock[Claimer]
+      claimer.start()
       cluster.claimer.returns(claimer)
+      claimer.requestClaim().answersWith(invocation => {
+        cluster.claimWork()
+        true
+      })
 
       val listener = new VerifyIntegrityListener(cluster, config)
       listener.nodeChanged("foo", "bar")
@@ -58,9 +62,13 @@ class VerifyIntegrityListenerSpec extends Spec {
       cluster.watchesRegistered.returns(new AtomicBoolean(true))
       cluster.initialized.returns(new AtomicBoolean(true))
 
-      val claimer = new Claimer(cluster)
-      claimer.start
+      val claimer = mock[Claimer]
+      claimer.start()
       cluster.claimer.returns(claimer)
+      claimer.requestClaim().answersWith(invocation => {
+        cluster.claimWork()
+        true
+      })
 
       val listener = new VerifyIntegrityListener(cluster, config)
       listener.nodeRemoved("foo")


### PR DESCRIPTION
Attempt to avoid a race condition by adding atomic deletes to Ordasity
when shutting down work units.

Includes fixes for unit tests which caused sporadic failures (depended
on sequencing of external thread - replaced with a Mock).
