### PR TITLE
Remove use of jerkson and use objectnode map.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,22 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>3.3.6</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>com.twitter.common.zookeeper</groupId>
             <artifactId>client</artifactId>
             <version>0.0.46</version>
@@ -56,9 +72,21 @@
         </dependency>
 
         <dependency>
-            <groupId>com.codahale</groupId>
-            <artifactId>jerkson_${scala.version}</artifactId>
-            <version>0.5.0-p03</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.1.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.1.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala</artifactId>
+            <version>2.1.2</version>
         </dependency>
         
         <dependency>

--- a/src/main/scala/com/boundary/ordasity/balancing/MeteredBalancingPolicy.scala
+++ b/src/main/scala/com/boundary/ordasity/balancing/MeteredBalancingPolicy.scala
@@ -19,9 +19,8 @@ package com.boundary.ordasity.balancing
 import collection.JavaConversions._
 import overlock.atomicmap.AtomicMap
 import com.boundary.ordasity._
-import com.codahale.jerkson.Json
 import java.util.concurrent.{TimeUnit, ScheduledFuture}
-import com.yammer.metrics.scala.{Meter, Instrumented}
+import com.yammer.metrics.scala.Meter
 import java.util.{TimerTask, LinkedList}
 import org.apache.zookeeper.CreateMode
 
@@ -124,7 +123,8 @@ class MeteredBalancingPolicy(cluster: Cluster, config: ClusterConfig)
 
           val myInfo = new NodeInfo(cluster.getState.toString, cluster.zk.get().getSessionId)
           val nodeLoadPath = "/%s/nodes/%s".format(cluster.name, cluster.myNodeID)
-          ZKUtils.setOrCreate(cluster.zk, nodeLoadPath, Json.generate(myInfo), CreateMode.EPHEMERAL)
+          val myInfoEncoded = JsonUtils.OBJECT_MAPPER.writeValueAsString(myInfo)
+          ZKUtils.setOrCreate(cluster.zk, nodeLoadPath, myInfoEncoded, CreateMode.EPHEMERAL)
 
           log.info("My load: %s", myLoad())          
         } catch {

--- a/src/main/scala/com/boundary/ordasity/listeners/VerifyIntegrityListener.scala
+++ b/src/main/scala/com/boundary/ordasity/listeners/VerifyIntegrityListener.scala
@@ -20,16 +20,17 @@ import collection.JavaConversions._
 import com.twitter.common.zookeeper.ZooKeeperMap
 import com.boundary.ordasity.{ClusterConfig, Cluster}
 import com.boundary.logula.Logging
+import com.fasterxml.jackson.databind.node.ObjectNode
 
 /**
  * As work units distributed about the cluster change, we must verify the
  * integrity of this node's mappings to ensure it matches reality, and attempt
  * to claim work if the topology of nodes and work units in the cluster has changed.
  */
-class VerifyIntegrityListener(cluster: Cluster, config: ClusterConfig)
-    extends ZooKeeperMap.Listener[String] with Logging {
+class VerifyIntegrityListener[T](cluster: Cluster, config: ClusterConfig)
+    extends ZooKeeperMap.Listener[T] with Logging {
 
-  def nodeChanged(nodeName: String, data: String) {
+  def nodeChanged(nodeName: String, data: T) {
     if (!cluster.initialized.get()) return
 
     log.debug(config.workUnitName.capitalize +

--- a/src/main/scala/com/boundary/ordasity/listeners/VerifyIntegrityListener.scala
+++ b/src/main/scala/com/boundary/ordasity/listeners/VerifyIntegrityListener.scala
@@ -20,7 +20,6 @@ import collection.JavaConversions._
 import com.twitter.common.zookeeper.ZooKeeperMap
 import com.boundary.ordasity.{ClusterConfig, Cluster}
 import com.boundary.logula.Logging
-import com.fasterxml.jackson.databind.node.ObjectNode
 
 /**
  * As work units distributed about the cluster change, we must verify the

--- a/src/test/scala/com/boundary/ordasity/Deserializers.scala
+++ b/src/test/scala/com/boundary/ordasity/Deserializers.scala
@@ -17,7 +17,6 @@
 package com.boundary.ordasity
 
 import org.junit.Test
-import com.codahale.jerkson.Json
 import com.simple.simplespec.Spec
 
 class DeserializersSpec extends Spec {
@@ -42,7 +41,7 @@ class DeserializersSpec extends Spec {
       val deser = new NodeInfoDeserializer
 
       val valid = NodeInfo("foo", 101L)
-      val bytes = Json.generate(valid).getBytes
+      val bytes = JsonUtils.OBJECT_MAPPER.writeValueAsBytes(valid)
 
       deser.apply(bytes).must(be(valid))
       deser.apply(null).must(be(NodeInfo(NodeState.Shutdown.toString, 0)))

--- a/src/test/scala/com/boundary/ordasity/balancing/MeteredBalancingPolicySpec.scala
+++ b/src/test/scala/com/boundary/ordasity/balancing/MeteredBalancingPolicySpec.scala
@@ -27,6 +27,7 @@ import java.util.{LinkedList, HashMap, UUID}
 import com.simple.simplespec.Spec
 import org.apache.zookeeper.data.Stat
 import com.google.common.base.Charsets
+import com.fasterxml.jackson.databind.node.ObjectNode
 
 class MeteredBalancingPolicySpec extends Spec {
 
@@ -118,7 +119,7 @@ class MeteredBalancingPolicySpec extends Spec {
       cluster.balancingPolicy = balancer
 
       Map("foo" -> 100.0, "bar" -> 200.0, "baz" -> 300.0).foreach(el =>
-        cluster.allWorkUnits.put(el._1, ""))
+        cluster.allWorkUnits.put(el._1, JsonUtils.OBJECT_MAPPER.createObjectNode()))
 
       cluster.loadMap = new HashMap[String, Double]
       cluster.loadMap.putAll(
@@ -140,7 +141,7 @@ class MeteredBalancingPolicySpec extends Spec {
       val map = Map("foo" -> 100.0, "bar" -> 200.0, "baz" -> 300.0)
 
       map.foreach(el =>
-        cluster.allWorkUnits.put(el._1, ""))
+        cluster.allWorkUnits.put(el._1, JsonUtils.OBJECT_MAPPER.createObjectNode()))
       cluster.myWorkUnits.addAll(map.keySet)
       map.keys.foreach(el =>
         cluster.zk.get().getData(equalTo(cluster.workUnitClaimPath(el)), any[Boolean], any[Stat])
@@ -165,7 +166,7 @@ class MeteredBalancingPolicySpec extends Spec {
       val map = Map("foo" -> 100.0, "bar" -> 200.0, "baz" -> 300.0)
 
       map.foreach(el =>
-        cluster.allWorkUnits.put(el._1, ""))
+        cluster.allWorkUnits.put(el._1, JsonUtils.OBJECT_MAPPER.createObjectNode()))
       cluster.myWorkUnits.addAll(map.keySet)
       map.keys.foreach(el =>
         cluster.zk.get().getData(equalTo(cluster.workUnitClaimPath(el)), any[Boolean], any[Stat])
@@ -191,7 +192,7 @@ class MeteredBalancingPolicySpec extends Spec {
       val map = Map("foo" -> 100.0, "bar" -> 200.0, "baz" -> 300.0)
 
       map.foreach(el =>
-        cluster.allWorkUnits.put(el._1, ""))
+        cluster.allWorkUnits.put(el._1, JsonUtils.OBJECT_MAPPER.createObjectNode()))
       map.keys.foreach(el =>
         cluster.zk.get().getData(equalTo(cluster.workUnitClaimPath(el)), any[Boolean], any[Stat])
           .returns(cluster.myNodeID.getBytes(Charsets.UTF_8))
@@ -228,7 +229,7 @@ class MeteredBalancingPolicySpec extends Spec {
     cluster.zk = mockZKClient
 
     cluster.nodes = new HashMap[String, NodeInfo]
-    cluster.allWorkUnits = new HashMap[String, String]
+    cluster.allWorkUnits = new HashMap[String, ObjectNode]
     cluster.workUnitMap = new HashMap[String, String]
     cluster.handoffRequests = new HashMap[String, String]
     cluster.handoffResults = new HashMap[String, String]

--- a/src/test/scala/com/boundary/ordasity/listeners/VerifyIntegrityListenerSpec.scala
+++ b/src/test/scala/com/boundary/ordasity/listeners/VerifyIntegrityListenerSpec.scala
@@ -50,7 +50,7 @@ class VerifyIntegrityListenerSpec extends Spec {
         true
       })
 
-      val listener = new VerifyIntegrityListener(cluster, config)
+      val listener = new VerifyIntegrityListener[String](cluster, config)
       listener.nodeChanged("foo", "bar")
 
       verify.one(cluster).claimWork()
@@ -82,7 +82,7 @@ class VerifyIntegrityListenerSpec extends Spec {
       cluster.watchesRegistered.returns(new AtomicBoolean(false))
       cluster.initialized.returns(new AtomicBoolean(false))
 
-      val listener = new VerifyIntegrityListener(cluster, config)
+      val listener = new VerifyIntegrityListener[String](cluster, config)
       listener.nodeChanged("foo", "bar")
 
       verify.exactly(0)(cluster).claimWork()
@@ -94,7 +94,7 @@ class VerifyIntegrityListenerSpec extends Spec {
       cluster.watchesRegistered.returns(new AtomicBoolean(false))
       cluster.initialized.returns(new AtomicBoolean(false))
 
-      val listener = new VerifyIntegrityListener(cluster, config)
+      val listener = new VerifyIntegrityListener[String](cluster, config)
       listener.nodeRemoved("foo")
 
       verify.exactly(0)(cluster).claimWork()


### PR DESCRIPTION
In order to facilitate re-use of the ZKMap for work units, create one
which maps from a work unit to an ObjectNode. Additionally, move all
JSON parsing from Jerkson / 1.9.x to Jackson 2.1.x.
